### PR TITLE
Implement tree column width handling in Sao

### DIFF
--- a/sao/src/sao.less
+++ b/sao/src/sao.less
@@ -376,6 +376,7 @@ img.icon {
             }
         }
         > thead > tr > th {
+            position: relative;
             > label.sortable {
                 cursor: pointer;
             }
@@ -390,6 +391,15 @@ img.icon {
             &.timedelta, &.float, &.numeric, &.integer, &.biginteger {
                 text-align: right;
                 text-align: end;
+            }
+            .resize-handle {
+                position: absolute;
+                right: 0;
+                top: 0;
+                bottom: 0;
+                width: 5px;
+                min-width: 5px;
+                cursor: col-resize;
             }
         }
         > thead > tr:first-child th {

--- a/sao/src/screen.js
+++ b/sao/src/screen.js
@@ -796,6 +796,14 @@
 
     Sao.Screen = Sao.class_(Object, {
         init: function(model_name, attributes) {
+            if (!Sao.Screen.tree_column_width) {
+                Sao.Screen.tree_column_width = {};
+            }
+            if (!Sao.Screen.tree_column_width[model_name]) {
+                Sao.Screen.tree_column_width[model_name] = {};
+            }
+            this.tree_column_width = Sao.Screen.tree_column_width;
+
             this.model_name = model_name;
             this.model = new Sao.Model(model_name, attributes);
             this.attributes = jQuery.extend({}, attributes);
@@ -898,7 +906,8 @@
                 view = this.views_preload[view_type];
             } else {
                 var prm = this.model.execute('fields_view_get',
-                        [view_id, view_type], this.context);
+                        [view_id, view_type],
+                        jQuery.extend({}, this.context, {view_tree_width: true}));
                 return prm.pipe(this.add_view.bind(this));
             }
             this.add_view(view);
@@ -1756,7 +1765,7 @@
             }
             if (!(view_id in this.fields_view_tree)) {
                 view_tree = this.model.execute('fields_view_get', [false, 'tree'],
-                    this.context, false);
+                    jQuery.extend({}, this.context, {view_tree_width: true}), false);
                 this.fields_view_tree[view_id] = view_tree;
             } else {
                 view_tree = this.fields_view_tree[view_id];

--- a/sao/src/view/tree.js
+++ b/sao/src/view/tree.js
@@ -233,7 +233,42 @@
                     th.click(column, this.sort_model.bind(this));
                     label.addClass('sortable');
                 }
-                tr.append(th.append(label));
+                var handle = jQuery('<span/>', {
+                    'class': 'resize-handle',
+                });
+                th.append(label).append(handle);
+                var stored = this.screen.tree_column_width[this.screen.model_name][column.attributes.name];
+                if (column.attributes.width) {
+                    this.screen.tree_column_width[this.screen.model_name][column.attributes.name] = parseInt(column.attributes.width, 10);
+                }
+                if (stored) {
+                    column.attributes.width = stored;
+                }
+                handle.on('mousedown', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var startX = e.pageX;
+                    var startWidth = column.col.width();
+                    var mousemove = function(ev) {
+                        var w = Math.max(5, startWidth + ev.pageX - startX);
+                        column.col.css('width', w);
+                    };
+                    var tree = this;
+                    var mouseup = function() {
+                        jQuery(document).off('mousemove.treeResize', mousemove);
+                        jQuery(document).off('mouseup.treeResize', mouseup);
+                        var width = parseInt(column.col.width(), 10);
+                        var fields = {};
+                        fields[column.attributes.name] = width;
+                        new Sao.Model('ir.ui.view_tree_width').execute('set_width', [tree.screen.model_name, fields], tree.screen.context);
+                        tree.screen.tree_column_width[tree.screen.model_name][column.attributes.name] = width;
+                        column.attributes.width = width;
+                    };
+                    jQuery(document).on('mousemove.treeResize', mousemove);
+                    jQuery(document).on('mouseup.treeResize', mouseup);
+                }.bind(this));
+
+                tr.append(th);
                 column.header = th;
                 column.col = col;
 
@@ -695,7 +730,11 @@
                     !column.col.hasClass('selection-state') &&
                     !column.col.hasClass('favorite')) {
                     var width, c_width;
-                    if (column.attributes.width) {
+                    var stored = this.screen.tree_column_width[this.screen.model_name][column.attributes.name];
+                    if (stored) {
+                        width = c_width = stored;
+                        min_width.push(width + 'px');
+                    } else if (column.attributes.width) {
                         width = c_width = column.attributes.width;
                         min_width.push(width + 'px');
                     } else {


### PR DESCRIPTION
## Summary
- add global tree_column_width cache to Sao.Screen
- pass `view_tree_width` context when retrieving views
- include resize handles on tree headers to adjust column width
- store column widths locally and persist via RPC
- style the resize handle in sao.less

## Testing
- `npm test` *(fails: cannot reach registry)*
- `npm run check` *(fails: missing @eslint/js module)*

------
https://chatgpt.com/codex/tasks/task_e_683bc9ce242c8329bad1d1eabf02c010